### PR TITLE
Fix wrong return value of setNetworkMode and setPreferredMode

### DIFF
--- a/examples/Arduino_TinyGSM/AllFunctions/AllFunctions.ino
+++ b/examples/Arduino_TinyGSM/AllFunctions/AllFunctions.ino
@@ -121,11 +121,11 @@ void setup() {
     38 LTE only
     51 GSM and LTE only
   * * * */
-  String res;
+  bool res;
   do {
     res = modem.setNetworkMode(38);
     delay(500);
-  } while (res != "OK");
+  } while (res != true);
 
   /*
     1 CAT-M
@@ -135,7 +135,7 @@ void setup() {
   do {
     res = modem.setPreferredMode(1);
     delay(500);
-  } while (res != "OK");
+  } while (res != true);
 
 }
 


### PR DESCRIPTION
The example doesn't work for me. I had an endless loop. The return value of setNetworkMode and setPreferredMode is not a string, it's a bool. See: 
https://github.com/vshymanskyy/TinyGSM/blob/07b402721d23e2b392251ad95cc157505bbeeb8d/src/TinyGsmClientSIM70xx.h#L213
